### PR TITLE
Fixed marquee not staying in the page correctly

### DIFF
--- a/style.css
+++ b/style.css
@@ -209,8 +209,7 @@ html{
   }
  div.marquee{
   z-index: 10;
-  position: -webkit-sticky;
-  position: sticky;
+  position: fixed;
   top:150px;
   margin:0;
   box-sizing: border-box;


### PR DESCRIPTION
The position: sticky CSS property works differently from position: fixed. When you set an element's position to sticky, it will act as a hybrid between position: relative and position: fixed, depending on the scroll position of the user.
In order to get something consistently on your screen, you should use the position: fixed.